### PR TITLE
Further make more clear how enderchest six-rows works

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -102,7 +102,7 @@ Requires the `bukkit.command.demo` permission ([Permissions](Permissions))
     - **description**: Ender chests should have 6 rows of inventory space
 * use-permissions-for-rows
     - **default**: false
-    - **description**: When set to false, all players will have 6 rows of inventory space for their respective container. When set to true, allows usage of the following permission nodes to determine the number of rows a player will have for the specified container:
+    - **description**: When set to false, all players will have 6 rows of enderchest inventory space. When set to true, allows usage of the following permission nodes to determine the number of rows of enderchest inventory space a player will have:
 
 <table>
     <thead>
@@ -112,7 +112,7 @@ Requires the `bukkit.command.demo` permission ([Permissions](Permissions))
     </thead>
     <tbody>
         <tr>
-            <td>Enderchest row permissions: 
+            <td>**Enderchest row permissions (default is six):
                 <ul>
                     <li style="list-style-type: none"><code> purpur.enderchest.rows.six </code></li>
                     <li style="list-style-type: none"><code> purpur.enderchest.rows.five </code></li>

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -102,7 +102,7 @@ Requires the `bukkit.command.demo` permission ([Permissions](Permissions))
     - **description**: Ender chests should have 6 rows of inventory space
 * use-permissions-for-rows
     - **default**: false
-    - **description**: Use permission nodes to determine the number of rows. By default, with this setting enabled, all players have six rows, unless otherwise denoted by permissions.
+    - **description**: When set to false, all players will have 6 rows of inventory space for their respective container. When set to true, allows usage of the following permission nodes to determine the number of rows a player will have for the specified container:
 
 <table>
     <thead>

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -112,7 +112,7 @@ Requires the `bukkit.command.demo` permission ([Permissions](Permissions))
     </thead>
     <tbody>
         <tr>
-            <td>**Enderchest row permissions (default is six):
+            <td>Enderchest row permissions (default is six):
                 <ul>
                     <li style="list-style-type: none"><code> purpur.enderchest.rows.six </code></li>
                     <li style="list-style-type: none"><code> purpur.enderchest.rows.five </code></li>


### PR DESCRIPTION
Previous PR said:
>Someone on discord got confused with that and I remember I was too when I tried this options for the first time, so this addition should clear things up a bit.

Yet again someone on discord got confused on the Discord, causing a massive loss of productivity in the support Discord and confusion among the meaning of the word "denote". Some people's vocabulary "in their world" may be different, and this commit accounts for that by clarifying these 2 lines in `configuration.md`.